### PR TITLE
Validate article URLs and handle summarize errors

### DIFF
--- a/src/news_summarize.py
+++ b/src/news_summarize.py
@@ -1,3 +1,5 @@
+import ipaddress
+import socket
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from flask import Blueprint
@@ -13,11 +15,45 @@ news_summarize = Blueprint('news_summarize', __name__, url_prefix='/')
 url_path_prefix = '/'
 _ARTICLE_CACHE = {}
 _TRACKING_PARAMS = {'fbclid', 'gclid', 'mc_cid', 'mc_eid'}
+_ALLOWED_SCHEMES = {'http', 'https'}
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network('127.0.0.0/8'),
+    ipaddress.ip_network('10.0.0.0/8'),
+    ipaddress.ip_network('172.16.0.0/12'),
+    ipaddress.ip_network('192.168.0.0/16'),
+    ipaddress.ip_network('169.254.0.0/16'),
+    ipaddress.ip_network('::1/128'),
+    ipaddress.ip_network('fc00::/7'),
+    ipaddress.ip_network('fe80::/10'),
+]
+
+
+class UrlValidationError(ValueError):
+    pass
 
 
 def set_flags(url_path):
     global url_path_prefix
     url_path_prefix = url_path
+
+
+def validate_article_url(url):
+    parsed = urlparse((url or '').strip())
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise UrlValidationError('article_url must use http or https')
+    if not parsed.hostname:
+        raise UrlValidationError('article_url must include a hostname')
+    if parsed.hostname.lower() in {'localhost', 'localhost.'}:
+        raise UrlValidationError('article_url must not point to localhost')
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UrlValidationError(f'could not resolve article_url hostname: {parsed.hostname}') from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if any(ip in network for network in _BLOCKED_NETWORKS):
+            raise UrlValidationError('article_url must not resolve to a private or local network')
+    return parsed.geturl()
 
 
 def normalize_url(url):
@@ -43,6 +79,7 @@ def clear_article_cache():
 
 
 def extract_article_data(article_url, article_cls=None):
+    article_url = validate_article_url(article_url)
     cache_key = normalize_url(article_url)
     if cache_key in _ARTICLE_CACHE:
         return _ARTICLE_CACHE[cache_key]
@@ -74,5 +111,10 @@ def summarize():
     payload = request.get_json(silent=True) or {}
     article_url = payload.get('article_url')
     if not article_url:
-        return jsonify({'error': 'article_url is required'}), 400
-    return jsonify(extract_article_data(article_url))
+        return jsonify({'error': {'code': 'missing_article_url', 'message': 'article_url is required'}}), 400
+    try:
+        return jsonify(extract_article_data(article_url))
+    except UrlValidationError as exc:
+        return jsonify({'error': {'code': 'invalid_article_url', 'message': str(exc)}}), 400
+    except Exception as exc:
+        return jsonify({'error': {'code': 'article_extraction_failed', 'message': str(exc)}}), 502

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,6 +8,7 @@
         function summarize() {
             const url = document.getElementById("article_url").value;
             document.getElementById("loading").style.display = "block";
+            document.getElementById("error").innerText = "";
             fetch("summarize", {
                 method: "POST",
                 headers: {
@@ -17,7 +18,13 @@
                     article_url: url
                 })
             })
-                .then((response) => response.json())
+                .then(async (response) => {
+                    const data = await response.json();
+                    if (!response.ok) {
+                        throw new Error(data.error?.message || "Failed to summarize article");
+                    }
+                    return data;
+                })
                 .then((data) => {
                     document.getElementById("loading").style.display = "none";
                     document.getElementById("title").innerText = data.title;
@@ -35,6 +42,11 @@
                     }
 
                     document.getElementById("results").style.display = "block";
+                })
+                .catch((error) => {
+                    document.getElementById("loading").style.display = "none";
+                    document.getElementById("results").style.display = "none";
+                    document.getElementById("error").innerText = error.message;
                 });
         }
     </script>
@@ -48,7 +60,8 @@
             <button type="button" onclick="summarize()">Summarize</button>
         </form>
     </div>
-    <img id="loading" src="static/loading-gif.gif" alt="Load me daddy" width="100" height="100" hidden>
+    <p id="error" style="color: red;"></p>
+    <img id="loading" src="static/loading-gif.gif" alt="Loading" width="100" height="100" hidden>
     <div id="results" hidden>
         <h1 id="title"></h1>
         <h3 id="authors"></h3>

--- a/test_app.sh
+++ b/test_app.sh
@@ -1,12 +1,11 @@
-#!/bin/sh
-if [[ -z "${VIRTUAL_ENV+x}" ]] ; then
-    python -m venv .venv
-    source .venv/bin/activate
-    pip install -r third_party/requirements.txt
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+  python3 -m venv .venv
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+  pip install -r third_party/requirements.txt
 fi
 
-if [[ $# -eq 0 ]] ; then
-    python wsgi.py 
-else
-    python wsgi.py $@
-fi
+python wsgi.py "$@"

--- a/tests/test_news_summarize.py
+++ b/tests/test_news_summarize.py
@@ -8,6 +8,8 @@ try:
         extract_article_data,
         news_summarize,
         normalize_url,
+        validate_article_url,
+        UrlValidationError,
     )
 except ModuleNotFoundError as exc:
     raise unittest.SkipTest(f'project runtime dependency missing: {exc.name}') from exc
@@ -52,7 +54,10 @@ class NewsSummarizeTests(unittest.TestCase):
         self.assertEqual(first, second)
 
     def test_extract_article_data_caches_by_normalized_url(self):
-        with patch('src.news_summarize.ensure_nltk_data'):
+        with patch('src.news_summarize.ensure_nltk_data'), patch(
+            'src.news_summarize.socket.getaddrinfo',
+            return_value=[(None, None, None, None, ('93.184.216.34', 0))],
+        ):
             first = extract_article_data(
                 'https://example.com/story?id=7&utm_source=x',
                 article_cls=FakeArticle,
@@ -74,7 +79,17 @@ class NewsSummarizeTests(unittest.TestCase):
         response = self.app().test_client().post('/summarize', json={})
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json()['error'], 'article_url is required')
+        self.assertEqual(response.get_json()['error']['code'], 'missing_article_url')
+
+    def test_validate_article_url_blocks_localhost(self):
+        with self.assertRaises(UrlValidationError):
+            validate_article_url('http://localhost:8000/story')
+
+    def test_summarize_route_returns_structured_url_error(self):
+        response = self.app().test_client().post('/summarize', json={'article_url': 'file:///etc/passwd'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()['error']['code'], 'invalid_article_url')
 
     def test_summarize_route_returns_extracted_data(self):
         with patch('src.news_summarize.extract_article_data', return_value={'title': 'T'}):


### PR DESCRIPTION
## Summary

Closes #6.
Closes #7.
Closes #8.

- Validate `article_url` before extraction.
- Allow only HTTP/S URLs and block localhost/private/link-local resolved IPs.
- Return structured error objects from `/summarize`.
- Show frontend fetch failures in the page instead of silently failing.
- Rewrite `test_app.sh` as bash-safe strict-mode script with safe arg forwarding.

## Tests

- `python3 -m unittest discover -s tests` — OK locally, skipped because Flask runtime dependency is not installed here
- `python3 -m py_compile src/news_summarize.py` — OK
- `bash -n test_app.sh` — OK