### PR TITLE
fix: wire URL prefix into frontend paths

### DIFF
--- a/src/news_summarize.py
+++ b/src/news_summarize.py
@@ -34,7 +34,12 @@ class UrlValidationError(ValueError):
 
 def set_flags(url_path):
     global url_path_prefix
-    url_path_prefix = url_path
+    prefix = url_path or '/'
+    if not prefix.startswith('/'):
+        prefix = '/' + prefix
+    if not prefix.endswith('/'):
+        prefix += '/'
+    url_path_prefix = prefix
 
 
 def validate_article_url(url):

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,13 +3,15 @@
 
 <head>
     <title>News Summary</title>
-    <link rel="icon" type="image/x-icon" href="static/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="{{ url_prefix }}static/favicon.ico">
     <script>
+        const summarizeUrl = "{{ url_prefix }}summarize";
+
         function summarize() {
             const url = document.getElementById("article_url").value;
             document.getElementById("loading").style.display = "block";
             document.getElementById("error").innerText = "";
-            fetch("summarize", {
+            fetch(summarizeUrl, {
                 method: "POST",
                 headers: {
                     'Content-Type': 'application/json'
@@ -61,7 +63,7 @@
         </form>
     </div>
     <p id="error" style="color: red;"></p>
-    <img id="loading" src="static/loading-gif.gif" alt="Loading" width="100" height="100" hidden>
+    <img id="loading" src="{{ url_prefix }}static/loading-gif.gif" alt="Loading" width="100" height="100" hidden>
     <div id="results" hidden>
         <h1 id="title"></h1>
         <h3 id="authors"></h3>

--- a/tests/test_news_summarize.py
+++ b/tests/test_news_summarize.py
@@ -8,6 +8,7 @@ try:
         extract_article_data,
         news_summarize,
         normalize_url,
+        set_flags,
         validate_article_url,
         UrlValidationError,
     )
@@ -40,6 +41,7 @@ class FakeArticle:
 class NewsSummarizeTests(unittest.TestCase):
     def setUp(self):
         clear_article_cache()
+        set_flags('/')
         FakeArticle.calls = 0
 
     def app(self):
@@ -74,6 +76,16 @@ class NewsSummarizeTests(unittest.TestCase):
         response = self.app().test_client().get('/')
 
         self.assertEqual(response.status_code, 200)
+
+    def test_index_route_uses_normalized_url_prefix_for_frontend_urls(self):
+        set_flags('news')
+
+        response = self.app().test_client().get('/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'href="/news/static/favicon.ico"', response.data)
+        self.assertIn(b'const summarizeUrl = "/news/summarize";', response.data)
+        self.assertIn(b'src="/news/static/loading-gif.gif"', response.data)
 
     def test_summarize_requires_article_url(self):
         response = self.app().test_client().post('/summarize', json={})


### PR DESCRIPTION
## Background

- Issues #1 and #3 ask for proxy-prefix support so the app can run behind a path prefix.

## What Has Changed

- Normalizes the `--url_path` flag to `/prefix/` shape.
- Uses the rendered prefix for favicon, loading image, and summarize POST path.
- Adds route coverage for prefixed frontend URLs.

## Screenshots/Video

- Left for author.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Reference Issue

- Closes #1
- Closes #3