### PR TITLE
fix: remove empty Docker apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ $ alias please="bazel"
 $ please run src:wsgi
 ```
 
+## Docker
+
+```bash
+docker build -f dockerfile -t news-summarize .
+docker run --rm -p 8080:8080 news-summarize
+```
+
 ## Tests
 
 ```bash

--- a/dockerfile
+++ b/dockerfile
@@ -9,11 +9,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 EXPOSE 8080
 
-RUN apt-get update \
- && apt-get install
-
-RUN pip install -r requirements.txt
-
 COPY . .
 
 CMD ["python", "wsgi.py"]


### PR DESCRIPTION
## Background

- Issue #4 reports the Dockerfile runs an empty `apt-get install` and installs requirements twice.

## What Has Changed

- Removed the invalid empty apt install layer.
- Removed the duplicate requirements install.
- Documented Docker build/run commands.

## Screenshots/Video

- Left for author.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Reference Issue

- Closes #4