### PR TITLE
fix: check NLTK data lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ $ alias please="bazel"
 $ please run src:wsgi
 ```
 
+## Docker
+
+```bash
+docker build -f dockerfile -t news-summarize .
+docker run --rm -p 8080:8080 news-summarize
+```
+
 ## Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ $ alias please="bazel"
 $ please run src:wsgi
 ```
 
+## Local setup
+
+```bash
+pip install -r third_party/requirements.txt
+python -m nltk.downloader punkt
+```
+
 ## Docker
 
 ```bash

--- a/dockerfile
+++ b/dockerfile
@@ -9,11 +9,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 EXPOSE 8080
 
-RUN apt-get update \
- && apt-get install
-
-RUN pip install -r requirements.txt
-
 COPY . .
 
 CMD ["python", "wsgi.py"]

--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 COPY third_party/requirements.txt ./
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt && \
+    python -m nltk.downloader punkt
 
 EXPOSE 8080
 

--- a/src/news_summarize.py
+++ b/src/news_summarize.py
@@ -32,6 +32,10 @@ class UrlValidationError(ValueError):
     pass
 
 
+class NltkDataError(RuntimeError):
+    pass
+
+
 def set_flags(url_path):
     global url_path_prefix
     url_path_prefix = url_path
@@ -70,8 +74,8 @@ def normalize_url(url):
 def ensure_nltk_data():
     try:
         nltk.data.find('tokenizers/punkt')
-    except LookupError:
-        nltk.download('punkt', quiet=True)
+    except LookupError as exc:
+        raise NltkDataError('Missing NLTK punkt data. Install it with: python -m nltk.downloader punkt') from exc
 
 
 def clear_article_cache():
@@ -116,5 +120,7 @@ def summarize():
         return jsonify(extract_article_data(article_url))
     except UrlValidationError as exc:
         return jsonify({'error': {'code': 'invalid_article_url', 'message': str(exc)}}), 400
+    except NltkDataError as exc:
+        return jsonify({'error': {'code': 'missing_nltk_data', 'message': str(exc)}}), 500
     except Exception as exc:
         return jsonify({'error': {'code': 'article_extraction_failed', 'message': str(exc)}}), 502

--- a/test_app.sh
+++ b/test_app.sh
@@ -6,6 +6,7 @@ if [[ -z "${VIRTUAL_ENV:-}" ]]; then
   # shellcheck disable=SC1091
   source .venv/bin/activate
   pip install -r third_party/requirements.txt
+  python -m nltk.downloader punkt
 fi
 
 python wsgi.py "$@"

--- a/tests/test_news_summarize.py
+++ b/tests/test_news_summarize.py
@@ -8,6 +8,7 @@ try:
         extract_article_data,
         news_summarize,
         normalize_url,
+        NltkDataError,
         validate_article_url,
         UrlValidationError,
     )
@@ -90,6 +91,16 @@ class NewsSummarizeTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json()['error']['code'], 'invalid_article_url')
+
+    def test_summarize_route_returns_missing_nltk_data_error(self):
+        with patch('src.news_summarize.extract_article_data', side_effect=NltkDataError('install punkt')):
+            response = self.app().test_client().post(
+                '/summarize',
+                json={'article_url': 'https://example.com/story'},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json()['error']['code'], 'missing_nltk_data')
 
     def test_summarize_route_returns_extracted_data(self):
         with patch('src.news_summarize.extract_article_data', return_value={'title': 'T'}):


### PR DESCRIPTION
## Background

- Issue #5 asks to avoid NLTK network downloads from the import/runtime path and make missing data actionable.

## What Has Changed

- Replaces runtime NLTK download with a clear missing-data error.
- Returns a structured `missing_nltk_data` API error.
- Installs `punkt` during local setup and Docker image setup.
- Adds route coverage for missing NLTK data.

## Screenshots/Video

- Left for author.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Reference Issue

- Closes #5